### PR TITLE
feat(aws): enable clients to use default auth provider chain if credentials are not provided

### DIFF
--- a/aws/config.go
+++ b/aws/config.go
@@ -94,7 +94,7 @@ func ValidateConfig(cfg *ClientConfig) (*ClientConfig, error) {
 		return nil, loafergo.ErrEmptyParam
 	}
 
-	if cfg.Config.Key == "" || cfg.Config.Secret == "" || cfg.Config.Region == "" {
+	if cfg.Config.Region == "" {
 		return nil, loafergo.ErrEmptyRequiredField
 	}
 
@@ -105,12 +105,20 @@ func ValidateConfig(cfg *ClientConfig) (*ClientConfig, error) {
 	return cfg, nil
 }
 
+// WithCredentialsProvider sets the credentials provider if provided
+func WithCredentialsProvider(c *aws.CredentialsCache) func(*config.LoadOptions) error {
+	return func(lo *config.LoadOptions) error {
+		lo.Credentials = c
+		return nil
+	}
+}
+
 // LoadAWSConfig loads aws config
 func LoadAWSConfig(ctx context.Context, cfg *ClientConfig, c *aws.CredentialsCache) (aCfg aws.Config, err error) {
 	conf := []func(*config.LoadOptions) error{
 		config.WithRegion(cfg.Config.Region),
-		config.WithCredentialsProvider(c),
 		config.WithRetryMaxAttempts(cfg.RetryCount),
+		WithCredentialsProvider(c),
 	}
 
 	if cfg.Config.Profile != "" {

--- a/aws/config_test.go
+++ b/aws/config_test.go
@@ -124,28 +124,6 @@ func TestSQSClientValidateConfig(t *testing.T) {
 			err:      loafergo.ErrEmptyRequiredField,
 			expected: nil,
 		},
-		{
-			name: "empty AWS Key",
-			cfg: &aws.ClientConfig{
-				Config: &aws.Config{
-					Secret: "dummy",
-					Region: "us-east-1",
-				},
-			},
-			err:      loafergo.ErrEmptyRequiredField,
-			expected: nil,
-		},
-		{
-			name: "empty AWS Secret",
-			cfg: &aws.ClientConfig{
-				Config: &aws.Config{
-					Key:    "dummy",
-					Region: "us-east-1",
-				},
-			},
-			err:      loafergo.ErrEmptyRequiredField,
-			expected: nil,
-		},
 	}
 	for _, tc := range testsCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/aws/sns/client.go
+++ b/aws/sns/client.go
@@ -18,10 +18,15 @@ func NewClient(ctx context.Context, cfg *loaferAWS.ClientConfig) (client loaferg
 		return nil, err
 	}
 
-	c := aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(cfg.Config.Key, cfg.Config.Secret, ""))
-	_, err = c.Retrieve(ctx)
-	if err != nil {
-		return client, loafergo.ErrInvalidCreds.Context(err)
+	var c *aws.CredentialsCache
+	// Check if static credentials are provided
+	if cfg.Config.Key != "" && cfg.Config.Secret != "" {
+		// Use static credentials if provided
+		c = aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(cfg.Config.Key, cfg.Config.Secret, ""))
+		_, err = c.Retrieve(ctx)
+		if err != nil {
+			return client, loafergo.ErrInvalidCreds.Context(err)
+		}
 	}
 
 	aCfg, err := loaferAWS.LoadAWSConfig(ctx, cfg, c)

--- a/aws/sns/client_test.go
+++ b/aws/sns/client_test.go
@@ -32,34 +32,6 @@ func TestNewProducer_ValidateConfig(t *testing.T) {
 			expectedErr: loafergo.ErrEmptyParam,
 		},
 		{
-			name: "Empty key",
-			cfg: &loaferAWS.ClientConfig{
-				Config: &loaferAWS.Config{
-					Key:        "",
-					Secret:     "secret",
-					Region:     "us-east-1",
-					Profile:    "profile",
-					Hostname:   "hostname",
-					Attributes: nil,
-				},
-			},
-			expectedErr: loafergo.ErrEmptyRequiredField,
-		},
-		{
-			name: "Empty Secret",
-			cfg: &loaferAWS.ClientConfig{
-				Config: &loaferAWS.Config{
-					Key:        "key",
-					Secret:     "",
-					Region:     "us-east-1",
-					Profile:    "profile",
-					Hostname:   "hostname",
-					Attributes: nil,
-				},
-			},
-			expectedErr: loafergo.ErrEmptyRequiredField,
-		},
-		{
 			name: "Empty Region",
 			cfg: &loaferAWS.ClientConfig{
 				Config: &loaferAWS.Config{

--- a/aws/sqs/client.go
+++ b/aws/sqs/client.go
@@ -18,12 +18,16 @@ func NewClient(ctx context.Context, cfg *loaferAWS.ClientConfig) (client loaferg
 		return nil, err
 	}
 
-	c := aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(cfg.Config.Key, cfg.Config.Secret, ""))
-	_, err = c.Retrieve(ctx)
-	if err != nil {
-		return client, loafergo.ErrInvalidCreds.Context(err)
+	var c *aws.CredentialsCache
+	// Check if static credentials are provided
+	if cfg.Config.Key != "" && cfg.Config.Secret != "" {
+		// Use static credentials if provided
+		c = aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(cfg.Config.Key, cfg.Config.Secret, ""))
+		_, err = c.Retrieve(ctx)
+		if err != nil {
+			return client, loafergo.ErrInvalidCreds.Context(err)
+		}
 	}
-
 	aCfg, err := loaferAWS.LoadAWSConfig(ctx, cfg, c)
 	if err != nil {
 		return nil, err

--- a/aws/sqs/client_test.go
+++ b/aws/sqs/client_test.go
@@ -13,20 +13,35 @@ import (
 )
 
 func TestSQSClientLoadConfig(t *testing.T) {
-	acc := &aws.CredentialsCache{}
-	cfg := &loaferAWS.ClientConfig{
-		Config: &loaferAWS.Config{
-			Key:      "dummy",
-			Secret:   "dummy",
-			Region:   "us-east-1",
-			Hostname: "",
-		},
-	}
-	ctx := context.Background()
+	t.Run("LoadAWSConfig with credentials", func(t *testing.T) {
+		acc := &aws.CredentialsCache{}
+		cfg := &loaferAWS.ClientConfig{
+			Config: &loaferAWS.Config{
+				Key:      "dummy",
+				Secret:   "dummy",
+				Region:   "us-east-1",
+				Hostname: "",
+			},
+		}
+		ctx := context.Background()
 
-	got, err := loaferAWS.LoadAWSConfig(ctx, cfg, acc)
-	assert.NoError(t, err)
-	assert.NotNil(t, got)
+		got, err := loaferAWS.LoadAWSConfig(ctx, cfg, acc)
+		assert.NoError(t, err)
+		assert.NotNil(t, got)
+	})
+
+	t.Run("LoadAWSConfig without credentials", func(t *testing.T) {
+		cfg := &loaferAWS.ClientConfig{
+			Config: &loaferAWS.Config{
+				Region: "us-east-1",
+			},
+		}
+		ctx := context.Background()
+
+		got, err := loaferAWS.LoadAWSConfig(ctx, cfg, nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, got)
+	})
 }
 
 func TestNewProducer_ValidateConfig(t *testing.T) {

--- a/aws/sqs/client_test.go
+++ b/aws/sqs/client_test.go
@@ -50,34 +50,6 @@ func TestNewProducer_ValidateConfig(t *testing.T) {
 			expectedErr: loafergo.ErrEmptyParam,
 		},
 		{
-			name: "Empty key",
-			cfg: &loaferAWS.ClientConfig{
-				Config: &loaferAWS.Config{
-					Key:        "",
-					Secret:     "secret",
-					Region:     "us-east-1",
-					Profile:    "profile",
-					Hostname:   "hostname",
-					Attributes: nil,
-				},
-			},
-			expectedErr: loafergo.ErrEmptyRequiredField,
-		},
-		{
-			name: "Empty Secret",
-			cfg: &loaferAWS.ClientConfig{
-				Config: &loaferAWS.Config{
-					Key:        "key",
-					Secret:     "",
-					Region:     "us-east-1",
-					Profile:    "profile",
-					Hostname:   "hostname",
-					Attributes: nil,
-				},
-			},
-			expectedErr: loafergo.ErrEmptyRequiredField,
-		},
-		{
 			name: "Empty Region",
 			cfg: &loaferAWS.ClientConfig{
 				Config: &loaferAWS.Config{


### PR DESCRIPTION
### Summary
This PR updates the NewClient function and LoadAWSConfig function to support both IAM role-based and static credentials authentication. The NewClient function now leverages the AWS SDK's default credential provider chain if static credentials are not provided. This changes affect both SQS and SNS clients.

 ### Benefits
Enhanced Flexibility: Automatically uses IAM roles if running in an AWS environment or static credentials if provided.
