### PR TITLE
Feat: add sns batch publish messages

### DIFF
--- a/aws/sns/producer.go
+++ b/aws/sns/producer.go
@@ -12,9 +12,49 @@ import (
 	loafergo "github.com/justcodes/loafer-go/v2"
 )
 
+const (
+	// DefaultMaxBatchSize is the default max batch size for sns
+	DefaultMaxBatchSize = 10
+)
+
 // Producer represents loafer sns producer
 type Producer interface {
 	Produce(ctx context.Context, input *PublishInput) (string, error)
+	ProduceBatch(ctx context.Context, input *PublishBatchInput) (*PublishBatchOutput, error)
+}
+
+// PublishBatchInput holds the sns batch publish attributes
+type PublishBatchInput struct {
+	Messages []*PublishBatchEntry
+	TopicARN string
+}
+
+// PublishBatchEntry holds the sns batch publish attributes
+// Each entry must have a unique ID to identify it in the request and response
+type PublishBatchEntry struct {
+	ID              string
+	Message         string
+	GroupID         string
+	DeduplicationID string
+	Attributes      map[string]string
+}
+
+// PublishBatchOutput holds the sns batch publish response
+type PublishBatchOutput struct {
+	Failed     []*PublishBatchEntryFailed
+	Successful []*PublishBatchEntrySuccessful
+}
+
+// PublishBatchEntrySuccessful holds the sns batch publish response
+type PublishBatchEntrySuccessful struct {
+	EntryID   string
+	MessageID string
+}
+
+// PublishBatchEntryFailed holds the sns batch publish response
+type PublishBatchEntryFailed struct {
+	EntryID string
+	Err     error
 }
 
 // PublishInput has the sns event attributes
@@ -76,6 +116,79 @@ func (p *producer) Produce(ctx context.Context, input *PublishInput) (string, er
 	}
 
 	return *result.MessageId, nil
+}
+
+// ProduceBatch publishes a batch of messages to an Amazon SNS topic. The messages are then sent to all
+// subscribers. Each entry must have a unique ID to identify it in the request and response
+// When the topic is a FIFO topic, the messages must also contain a group ID
+// and, when ID-based deduplication is used, a deduplication ID. An optional key-value
+// filter attribute can be specified so that the messages can be filtered according to
+// a filter policy.
+func (p *producer) ProduceBatch(ctx context.Context, input *PublishBatchInput) (*PublishBatchOutput, error) {
+	if input == nil || reflect.DeepEqual(input, &PublishBatchInput{}) || len(input.Messages) == 0 {
+		return nil, loafergo.ErrEmptyInput
+	}
+
+	if len(input.Messages) > DefaultMaxBatchSize {
+		return nil, fmt.Errorf("maximum batch size is %d", DefaultMaxBatchSize)
+	}
+
+	pubInp := &sns.PublishBatchInput{
+		TopicArn: aws.String(input.TopicARN),
+	}
+
+	for _, msg := range input.Messages {
+		message := types.PublishBatchRequestEntry{
+			Id:      aws.String(msg.ID),
+			Message: aws.String(msg.Message),
+		}
+
+		if msg.GroupID != "" {
+			message.MessageGroupId = aws.String(msg.GroupID)
+		}
+
+		if msg.DeduplicationID != "" {
+			message.MessageDeduplicationId = aws.String(msg.DeduplicationID)
+		}
+
+		if len(msg.Attributes) > 0 {
+			message.MessageAttributes = p.messageAttributes(msg.Attributes)
+		}
+
+		pubInp.PublishBatchRequestEntries = append(pubInp.PublishBatchRequestEntries, message)
+	}
+
+	result, err := p.sns.PublishBatch(ctx, pubInp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to publish messages; topic: %s  error: %w", input.TopicARN, err)
+	}
+
+	return &PublishBatchOutput{
+		Failed:     p.getFailedEntries(result.Failed),
+		Successful: p.getSuccessfulEntries(result.Successful),
+	}, nil
+}
+
+func (p *producer) getSuccessfulEntries(entries []types.PublishBatchResultEntry) []*PublishBatchEntrySuccessful {
+	successful := make([]*PublishBatchEntrySuccessful, len(entries))
+	for i, entry := range entries {
+		successful[i] = &PublishBatchEntrySuccessful{
+			EntryID:   *entry.Id,
+			MessageID: *entry.MessageId,
+		}
+	}
+	return successful
+}
+
+func (p *producer) getFailedEntries(entries []types.BatchResultErrorEntry) []*PublishBatchEntryFailed {
+	failed := make([]*PublishBatchEntryFailed, len(entries))
+	for i, entry := range entries {
+		failed[i] = &PublishBatchEntryFailed{
+			EntryID: *entry.Id,
+			Err:     fmt.Errorf("failed to publish message; error: %s", *entry.Message),
+		}
+	}
+	return failed
 }
 
 func (p *producer) messageAttributes(attr map[string]string) map[string]types.MessageAttributeValue {

--- a/aws/sns/producer_test.go
+++ b/aws/sns/producer_test.go
@@ -234,3 +234,471 @@ func (suite *producerSuite) TestPublish() {
 		suite.ErrorIs(err, loafergo.ErrEmptyInput)
 	})
 }
+
+func (suite *producerSuite) TestPublishBatch() {
+	ctx := context.Background()
+	suite.Run("Should produce with Success", func() {
+		topicArn, err := sns.BuildTopicARN("us-east-1", "0000000", "my_topic")
+		suite.NoError(err)
+
+		input := sns.PublishBatchInput{
+			Messages: []*sns.PublishBatchEntry{
+				{
+					ID:      "id",
+					Message: "my message",
+				},
+			},
+			TopicARN: topicArn,
+		}
+
+		param := &awsSNS.PublishBatchInput{
+			TopicArn: aws.String(input.TopicARN),
+			PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
+				{
+					Id:      aws.String(input.Messages[0].ID),
+					Message: aws.String(input.Messages[0].Message),
+				},
+			},
+		}
+
+		rID := "id"
+
+		suite.snsCLient.On("PublishBatch", ctx, param).
+			Return(
+				&awsSNS.PublishBatchOutput{
+					Successful: []types.PublishBatchResultEntry{
+						{
+							Id:        aws.String(input.Messages[0].ID),
+							MessageId: aws.String(rID),
+						},
+					},
+				},
+				nil,
+			).
+			Once()
+
+		got, err := suite.producer.ProduceBatch(ctx, &input)
+		suite.NoError(err)
+		suite.Equal("id", got.Successful[0].MessageID)
+
+	})
+
+	suite.Run("Should produce many messages", func() {
+		topicArn, err := sns.BuildTopicARN("us-east-1", "0000000", "my_topic")
+		suite.NoError(err)
+
+		input := sns.PublishBatchInput{
+			Messages: []*sns.PublishBatchEntry{
+				{
+					ID:      "id1",
+					Message: "my message 1",
+				},
+				{
+					ID:      "id2",
+					Message: "my message 2",
+				},
+				{
+					ID:      "id3",
+					Message: "my message 3",
+				},
+			},
+			TopicARN: topicArn,
+		}
+		param := &awsSNS.PublishBatchInput{
+			TopicArn: aws.String(input.TopicARN),
+			PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
+				{
+					Id:      aws.String(input.Messages[0].ID),
+					Message: aws.String(input.Messages[0].Message),
+				},
+				{
+					Id:      aws.String(input.Messages[1].ID),
+					Message: aws.String(input.Messages[1].Message),
+				},
+				{
+					Id:      aws.String(input.Messages[2].ID),
+					Message: aws.String(input.Messages[2].Message),
+				},
+			},
+		}
+		rID1 := "id1"
+		rID2 := "id2"
+		rID3 := "id3"
+
+		suite.snsCLient.On("PublishBatch", ctx, param).
+			Return(
+				&awsSNS.PublishBatchOutput{
+					Successful: []types.PublishBatchResultEntry{
+						{
+							Id:        aws.String(input.Messages[0].ID),
+							MessageId: aws.String(rID1),
+						},
+						{
+							Id:        aws.String(input.Messages[1].ID),
+							MessageId: aws.String(rID2),
+						},
+						{
+							Id:        aws.String(input.Messages[2].ID),
+							MessageId: aws.String(rID3),
+						},
+					},
+				},
+				nil,
+			).
+			Once()
+		got, err := suite.producer.ProduceBatch(ctx, &input)
+		suite.NoError(err)
+		suite.Equal("id1", got.Successful[0].MessageID)
+		suite.Equal("id2", got.Successful[1].MessageID)
+		suite.Equal("id3", got.Successful[2].MessageID)
+	})
+
+	suite.Run("Should produce and all messages fail", func() {
+		topicArn, err := sns.BuildTopicARN("us-east-1", "0000000", "my_topic")
+		suite.NoError(err)
+		input := sns.PublishBatchInput{
+			Messages: []*sns.PublishBatchEntry{
+				{
+					ID:      "id1",
+					Message: "my message 1",
+				},
+				{
+					ID:      "id2",
+					Message: "my message 2",
+				},
+			},
+			TopicARN: topicArn,
+		}
+
+		param := &awsSNS.PublishBatchInput{
+			TopicArn: aws.String(input.TopicARN),
+			PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
+				{
+					Id:      aws.String(input.Messages[0].ID),
+					Message: aws.String(input.Messages[0].Message),
+				},
+				{
+					Id:      aws.String(input.Messages[1].ID),
+					Message: aws.String(input.Messages[1].Message),
+				},
+			},
+		}
+
+		suite.snsCLient.On("PublishBatch", ctx, param).
+			Return(
+				&awsSNS.PublishBatchOutput{
+					Failed: []types.BatchResultErrorEntry{
+						{
+							Id:      aws.String(input.Messages[0].ID),
+							Message: aws.String("error"),
+						},
+						{
+							Id:      aws.String(input.Messages[1].ID),
+							Message: aws.String("error"),
+						},
+					},
+				}, nil).
+			Once()
+		got, err := suite.producer.ProduceBatch(ctx, &input)
+		suite.NoError(err)
+		suite.Equal(2, len(got.Failed))
+		suite.Equal("id1", got.Failed[0].EntryID)
+		suite.Equal("failed to publish message; error: error", got.Failed[0].Err.Error())
+		suite.Equal("id2", got.Failed[1].EntryID)
+		suite.Equal("failed to publish message; error: error", got.Failed[1].Err.Error())
+	})
+
+	suite.Run("Should produce and some messages fail", func() {
+		topicArn, err := sns.BuildTopicARN("us-east-1", "0000000", "my_topic")
+		suite.NoError(err)
+		input := sns.PublishBatchInput{
+			Messages: []*sns.PublishBatchEntry{
+				{
+					ID:      "id1",
+					Message: "my message 1",
+				},
+				{
+					ID:      "id2",
+					Message: "my message 2",
+				},
+			},
+			TopicARN: topicArn,
+		}
+
+		param := &awsSNS.PublishBatchInput{
+			TopicArn: aws.String(input.TopicARN),
+			PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
+				{
+					Id:      aws.String(input.Messages[0].ID),
+					Message: aws.String(input.Messages[0].Message),
+				},
+				{
+					Id:      aws.String(input.Messages[1].ID),
+					Message: aws.String(input.Messages[1].Message),
+				},
+			},
+		}
+
+		suite.snsCLient.On("PublishBatch", ctx, param).
+			Return(
+				&awsSNS.PublishBatchOutput{
+					Successful: []types.PublishBatchResultEntry{
+						{
+							Id:        aws.String(input.Messages[0].ID),
+							MessageId: aws.String("id123"),
+						},
+					},
+					Failed: []types.BatchResultErrorEntry{
+						{
+							Id:      aws.String(input.Messages[1].ID),
+							Message: aws.String("error"),
+						},
+					},
+				}, nil).
+			Once()
+		got, err := suite.producer.ProduceBatch(ctx, &input)
+		suite.NoError(err)
+		suite.Equal(1, len(got.Successful))
+		suite.Equal(1, len(got.Failed))
+		suite.Equal("id1", got.Successful[0].EntryID)
+		suite.Equal("id123", got.Successful[0].MessageID)
+		suite.Equal("id2", got.Failed[0].EntryID)
+		suite.Equal("failed to publish message; error: error", got.Failed[0].Err.Error())
+	})
+
+	suite.Run("Should produce with message attributes", func() {
+		topicArn, err := sns.BuildTopicARN("us-east-1", "0000000", "my_topic")
+		suite.NoError(err)
+		input := sns.PublishBatchInput{
+			Messages: []*sns.PublishBatchEntry{
+				{
+					ID:      "id",
+					Message: "my message",
+					Attributes: map[string]string{
+						"custom": "custom_value",
+					},
+				},
+			},
+			TopicARN: topicArn,
+		}
+		param := &awsSNS.PublishBatchInput{
+			TopicArn: aws.String(input.TopicARN),
+			PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
+				{
+					Id:      aws.String(input.Messages[0].ID),
+					Message: aws.String(input.Messages[0].Message),
+					MessageAttributes: map[string]types.MessageAttributeValue{
+						"custom": {DataType: aws.String("String"), StringValue: aws.String("custom_value")},
+					},
+				},
+			},
+		}
+
+		rID := "id-123"
+		suite.snsCLient.On("PublishBatch", ctx, param).
+			Return(
+				&awsSNS.PublishBatchOutput{
+					Successful: []types.PublishBatchResultEntry{
+						{
+							Id:        aws.String(input.Messages[0].ID),
+							MessageId: aws.String(rID),
+						},
+					},
+				},
+				nil,
+			).
+			Once()
+
+		got, err := suite.producer.ProduceBatch(ctx, &input)
+		suite.NoError(err)
+		suite.Equal("id-123", got.Successful[0].MessageID)
+	})
+
+	suite.Run("Should produce with GroupID", func() {
+		topicArn, err := sns.BuildTopicARN("us-east-1", "0000000", "my_topic")
+		suite.NoError(err)
+
+		input := sns.PublishBatchInput{
+			Messages: []*sns.PublishBatchEntry{
+				{
+					ID:      "id",
+					Message: "my message",
+					GroupID: "my-group",
+				},
+			},
+			TopicARN: topicArn,
+		}
+
+		param := &awsSNS.PublishBatchInput{
+			TopicArn: aws.String(input.TopicARN),
+			PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
+				{
+					Id:             aws.String(input.Messages[0].ID),
+					Message:        aws.String(input.Messages[0].Message),
+					MessageGroupId: aws.String("my-group"),
+				},
+			},
+		}
+
+		rID := "id"
+		suite.snsCLient.On("PublishBatch", ctx, param).
+			Return(
+				&awsSNS.PublishBatchOutput{
+					Successful: []types.PublishBatchResultEntry{
+						{
+							Id:        aws.String(input.Messages[0].ID),
+							MessageId: aws.String(rID),
+						},
+					},
+				},
+				nil,
+			).
+			Once()
+
+		got, err := suite.producer.ProduceBatch(ctx, &input)
+		suite.NoError(err)
+		suite.Equal("id", got.Successful[0].MessageID)
+	})
+
+	suite.Run("Should produce with all fields", func() {
+		topicArn, err := sns.BuildTopicARN("us-east-1", "0000000", "my_topic")
+		suite.NoError(err)
+
+		input := sns.PublishBatchInput{
+			Messages: []*sns.PublishBatchEntry{
+				{
+					ID:              "id",
+					Message:         "my message",
+					GroupID:         "my-group",
+					DeduplicationID: "dedup-id",
+					Attributes: map[string]string{
+						"custom": "custom_value",
+					},
+				},
+			},
+			TopicARN: topicArn,
+		}
+
+		param := &awsSNS.PublishBatchInput{
+			TopicArn: aws.String(input.TopicARN),
+			PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
+				{
+					Id:      aws.String(input.Messages[0].ID),
+					Message: aws.String(input.Messages[0].Message),
+					MessageAttributes: map[string]types.MessageAttributeValue{
+						"custom": {DataType: aws.String("String"), StringValue: aws.String("custom_value")},
+					},
+					MessageGroupId:         aws.String("my-group"),
+					MessageDeduplicationId: aws.String("dedup-id"),
+				},
+			},
+		}
+
+		rID := "id"
+		suite.snsCLient.On("PublishBatch", ctx, param).
+			Return(
+				&awsSNS.PublishBatchOutput{
+					Successful: []types.PublishBatchResultEntry{
+						{
+							Id:        aws.String(input.Messages[0].ID),
+							MessageId: aws.String(rID),
+						},
+					},
+				},
+				nil,
+			).
+			Once()
+
+		got, err := suite.producer.ProduceBatch(ctx, &input)
+		suite.NoError(err)
+		suite.Equal("id", got.Successful[0].MessageID)
+	})
+
+	suite.Run("SNS PublishBatch error", func() {
+		topicArn, err := sns.BuildTopicARN("us-east-1", "0000000", "my_topic")
+		suite.NoError(err)
+
+		input := sns.PublishBatchInput{
+			Messages: []*sns.PublishBatchEntry{
+				{
+					ID:              "id",
+					Message:         "my message",
+					GroupID:         "my-group",
+					DeduplicationID: "dedup-id",
+					Attributes: map[string]string{
+						"custom": "custom_value",
+					},
+				},
+			},
+			TopicARN: topicArn,
+		}
+
+		param := &awsSNS.PublishBatchInput{
+			TopicArn: aws.String(input.TopicARN),
+			PublishBatchRequestEntries: []types.PublishBatchRequestEntry{
+				{
+					Id:      aws.String(input.Messages[0].ID),
+					Message: aws.String(input.Messages[0].Message),
+					MessageAttributes: map[string]types.MessageAttributeValue{
+						"custom": {DataType: aws.String("String"), StringValue: aws.String("custom_value")},
+					},
+					MessageGroupId:         aws.String("my-group"),
+					MessageDeduplicationId: aws.String("dedup-id"),
+				},
+			},
+		}
+
+		suite.snsCLient.On("PublishBatch", ctx, param).
+			Return(nil, fmt.Errorf("got error")).
+			Once()
+
+		got, err := suite.producer.ProduceBatch(ctx, &input)
+		suite.Empty(got)
+		suite.NotNil(err)
+		suite.ErrorContains(err, "got error")
+	})
+
+	suite.Run("With Input nil", func() {
+		got, err := suite.producer.ProduceBatch(ctx, nil)
+		suite.Empty(got)
+		suite.NotNil(err)
+		suite.ErrorIs(err, loafergo.ErrEmptyInput)
+	})
+
+	suite.Run("With emtpy Messages", func() {
+		topicArn, err := sns.BuildTopicARN("us-east-1", "0000000", "my_topic")
+		suite.NoError(err)
+
+		input := sns.PublishBatchInput{
+			Messages: []*sns.PublishBatchEntry{},
+			TopicARN: topicArn,
+		}
+
+		got, err := suite.producer.ProduceBatch(ctx, &input)
+		suite.Empty(got)
+		suite.NotNil(err)
+		suite.ErrorIs(err, loafergo.ErrEmptyInput)
+	})
+
+	suite.Run("Too many batch messages", func() {
+		topicArn, err := sns.BuildTopicARN("us-east-1", "0000000", "my_topic")
+		suite.NoError(err)
+
+		input := sns.PublishBatchInput{
+			Messages: []*sns.PublishBatchEntry{},
+			TopicARN: topicArn,
+		}
+
+		for i := 0; i < sns.DefaultMaxBatchSize+1; i++ {
+			input.Messages = append(input.Messages, &sns.PublishBatchEntry{
+				ID:      fmt.Sprintf("id-%d", i),
+				Message: fmt.Sprintf("my message %d", i),
+			})
+		}
+
+		got, err := suite.producer.ProduceBatch(ctx, &input)
+		suite.Empty(got)
+		suite.NotNil(err)
+		suite.ErrorContains(err, fmt.Sprintf("maximum batch size is %d", sns.DefaultMaxBatchSize))
+	})
+}

--- a/example/README.md
+++ b/example/README.md
@@ -37,6 +37,8 @@ Message produced to topic my_topic__test; id: f8db976f-1631-43ce-9806-787196b516
 Message produced to topic my_topic__test; id: 373eb406-d4f3-415b-9729-fdba291c4f12 
 Message produced to topic my_topic__test2; id: 60f5aed8-9429-42f8-ad2f-fd03e3d87a34 
 Message produced to topic my_topic__test2; id: 10d7c4a9-88f5-4730-9328-8c2f110fd7a7 
+Messages produced in batch to topic my_topic__test2, IDs: 2b8ec1ed-cd0a-42e7-8bcb-e33462933fc9 923c0f6b-f9b6-4f7c-8b99-ae42a0d5e7eb 536ba129-93e2-4098-aee5-776371c83add f16347b5-31dc-4eec-89be-085b63d79379 b4aca82a-9fcd-4b05-9b79-d66b7c498c51 a72cb949-542a-4f5a-b106-19b14063ecbe f7f7dd93-eb5b-4f49-90ab-1d538c7fcc20 c746e8b7-c55d-4e06-aaf2-e2a29e1b90b8 e7e4442c-77a7-4058-ae1d-4facee32fd21 ee7e7b5e-4e26-40fe-a7fa-fdd458eda025 
+Messages produced in batch to topic my_topic__test, IDs: f4428d9a-01f7-4297-a53e-e98e0f552973 5754631d-2e43-41b1-9f01-5a27de953e95 4d4d36a3-3169-49a9-ab37-011be6eb590f cc31ef8b-c821-469d-839b-205f4e7bb41d fc3c5c84-f6cc-4711-962a-6285b00493a1 46ba3bb4-447b-489a-a36c-9a32e5f9f110 84a7e4b7-028f-4639-8113-54ae81931b11 be78d097-36c8-4975-931b-96e43a7882ea b157f5a2-afb5-4727-a6c9-e52702ac0a2c f6d94c92-c0c6-47c3-b738-01441408500e 
 ...
 
 


### PR DESCRIPTION
### Summary

This PR enables users to send SNS messages to a topic in batch, the max batch size is 10 messages.

### Benefits

Enhanced performance and resource usage.