### PR TITLE
Only extend SQS visibility timeout when a message is still being processed

### DIFF
--- a/.github/workflows/stages.yml
+++ b/.github/workflows/stages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
       - name: Test
         run: go test -timeout 1m -race -covermode=atomic -coverprofile=tmp.out ./... && cat tmp.out | grep -Ev 'example|fake' > geral.out  && go tool cover -func=geral.out
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version-file: go.mod
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,12 @@ check: lint test
 test-bench:
 	@$(MAKE) -s clean
 	@go test -bench=. ./... -benchtime=5s -count 1 -benchmem
+
+# Run integration tests against a real LocalStack SQS queue
+test-integration:
+	@echo "Starting LocalStack..."
+	@docker compose -f docker-compose.integration.yml up -d
+	@echo "Waiting for LocalStack to be ready..."
+	@until curl -s http://localhost:4566/_localstack/health | grep -q '"sqs": "\(running\|available\)"'; do sleep 1; done
+	@go test -tags=integration -race -v ./aws/sqs/... -run Integration || (docker compose -f docker-compose.integration.yml down -v && exit 1)
+	@docker compose -f docker-compose.integration.yml down -v

--- a/aws/sqs/route.go
+++ b/aws/sqs/route.go
@@ -99,6 +99,7 @@ func (r *route) GetMessages(ctx context.Context, logger loafergo.Logger) (messag
 			QueueUrl:                    &r.queueURL,
 			WaitTimeSeconds:             r.waitTimeSeconds,
 			MaxNumberOfMessages:         r.maxMessages,
+			VisibilityTimeout:           r.visibilityTimeout,
 			MessageAttributeNames:       []string{all},
 			MessageSystemAttributeNames: []types.MessageSystemAttributeName{types.MessageSystemAttributeNameAll},
 		},
@@ -166,6 +167,10 @@ func (r *route) CustomGroupFields(ctx context.Context) []string {
 	return r.customGroupFields
 }
 
+// changeMessageVisibility only extends the message visibility timeout when processing
+// is still ongoing after it. Since ReceiveMessage already requests VisibilityTimeout
+// equal to r.visibilityTimeout, messages committed or dispatched before the first tick
+// never trigger a ChangeMessageVisibility call.
 func (r *route) changeMessageVisibility(ctx context.Context, m *message, logger loafergo.Logger) {
 	var count int
 	extension := r.visibilityTimeout
@@ -173,12 +178,10 @@ func (r *route) changeMessageVisibility(ctx context.Context, m *message, logger 
 	ticker := time.NewTicker(sleepTime)
 	defer ticker.Stop()
 
-	r.doChangeVisibilityTimeout(ctx, m, extension, logger)
-
 	for {
-		// only allow extensionLimit extension (Default 1m30s)
-		if count >= r.extensionLimit {
-			break
+		// only allow extensionLimit extension (Default 1m30s) beyond the first renewal
+		if count > r.extensionLimit {
+			return
 		}
 
 		select {
@@ -188,10 +191,12 @@ func (r *route) changeMessageVisibility(ctx context.Context, m *message, logger 
 		case <-m.dispatched:
 			return
 		case <-ticker.C:
-			count++
-			// double the allowed processing time
-			extension += r.visibilityTimeout
+			// the first tick just renews the original timeout, subsequent ticks double it
+			if count > 0 {
+				extension += r.visibilityTimeout
+			}
 			r.doChangeVisibilityTimeout(ctx, m, extension, logger)
+			count++
 		}
 	}
 }

--- a/aws/sqs/route_test.go
+++ b/aws/sqs/route_test.go
@@ -119,7 +119,7 @@ func (suite *routeSuite) TestGetMessages() {
 
 	suite.Run("Should return the messages", func() {
 		suite.route = suite.setupRouter()
-		ctx, done := setupContext(1)
+		ctx := context.Background()
 		cParam := &awsSqs.GetQueueUrlInput{QueueName: aws.String("example-1")}
 		suite.sqsClient.On("GetQueueUrl", ctx, cParam).
 			Return(&awsSqs.GetQueueUrlOutput{QueueUrl: aws.String("example-1-url")}, nil).
@@ -131,6 +131,7 @@ func (suite *routeSuite) TestGetMessages() {
 			QueueUrl:                    aws.String("example-1-url"),
 			WaitTimeSeconds:             8,
 			MaxNumberOfMessages:         15,
+			VisibilityTimeout:           12,
 			MessageAttributeNames:       []string{"All"},
 			MessageSystemAttributeNames: []types.MessageSystemAttributeName{types.MessageSystemAttributeNameAll},
 		}
@@ -143,24 +144,26 @@ func (suite *routeSuite) TestGetMessages() {
 			}, nil).
 			Once()
 
-		suite.sqsClient.On("ChangeMessageVisibility", ctx, &awsSqs.ChangeMessageVisibilityInput{
-			QueueUrl:          aws.String("example-1-url"),
-			ReceiptHandle:     aws.String("receipt-handle"),
-			VisibilityTimeout: int32(12),
-		}).Return(nil, nil).Once()
-
+		// No ChangeMessageVisibility call is expected: it is only made if the message
+		// is still being processed once the visibility timeout is close to expiring.
 		messages, err := suite.route.GetMessages(ctx, logger)
 		suite.NoError(err)
-		<-done
 
 		suite.Len(messages, 1)
 		suite.Equal("hello world", string(messages[0].Body()))
 
+		// commit to dispatch the message, otherwise its changeMessageVisibility
+		// goroutine keeps ticking in the background for the rest of the test run.
+		suite.sqsClient.On("DeleteMessage", ctx, &awsSqs.DeleteMessageInput{
+			QueueUrl:      aws.String("example-1-url"),
+			ReceiptHandle: aws.String("receipt-handle"),
+		}).Return(nil, nil).Once()
+		suite.NoError(suite.route.Commit(ctx, messages[0]))
 	})
 
 	suite.Run("Should return error when receive message", func() {
 		suite.route = suite.setupRouter()
-		ctx, done := setupContext(1)
+		ctx := context.Background()
 		cParam := &awsSqs.GetQueueUrlInput{QueueName: aws.String("example-1")}
 		suite.sqsClient.On("GetQueueUrl", ctx, cParam).
 			Return(&awsSqs.GetQueueUrlOutput{QueueUrl: aws.String("example-1-url")}, nil).
@@ -172,6 +175,7 @@ func (suite *routeSuite) TestGetMessages() {
 			QueueUrl:                    aws.String("example-1-url"),
 			WaitTimeSeconds:             8,
 			MaxNumberOfMessages:         15,
+			VisibilityTimeout:           12,
 			MessageAttributeNames:       []string{"All"},
 			MessageSystemAttributeNames: []types.MessageSystemAttributeName{types.MessageSystemAttributeNameAll},
 		}
@@ -179,7 +183,6 @@ func (suite *routeSuite) TestGetMessages() {
 			Return(nil, fmt.Errorf("got error")).
 			Once()
 
-		done <- true // wont call change message visibility
 		messages, err := suite.route.GetMessages(ctx, logger)
 		suite.NotNil(err)
 
@@ -203,7 +206,7 @@ func (suite *routeSuite) TestCommit() {
 
 	suite.Run("Should commit commit", func() {
 		suite.route = suite.setupRouter()
-		ctx, done := setupContext(1)
+		ctx := context.Background()
 		cParam := &awsSqs.GetQueueUrlInput{QueueName: aws.String("example-1")}
 		suite.sqsClient.On("GetQueueUrl", ctx, cParam).
 			Return(&awsSqs.GetQueueUrlOutput{QueueUrl: aws.String("example-1-url")}, nil).
@@ -215,6 +218,7 @@ func (suite *routeSuite) TestCommit() {
 			QueueUrl:                    aws.String("example-1-url"),
 			WaitTimeSeconds:             8,
 			MaxNumberOfMessages:         15,
+			VisibilityTimeout:           12,
 			MessageAttributeNames:       []string{"All"},
 			MessageSystemAttributeNames: []types.MessageSystemAttributeName{types.MessageSystemAttributeNameAll},
 		}
@@ -227,16 +231,9 @@ func (suite *routeSuite) TestCommit() {
 			}, nil).
 			Once()
 
-		suite.sqsClient.On("ChangeMessageVisibility", ctx, &awsSqs.ChangeMessageVisibilityInput{
-			QueueUrl:          aws.String("example-1-url"),
-			ReceiptHandle:     aws.String("receipt-handle"),
-			VisibilityTimeout: int32(12),
-		}).Return(nil, nil).Once()
-
+		// message is committed right away, so no ChangeMessageVisibility call is expected
 		message, err := suite.route.GetMessages(ctx, logger)
 		suite.NoError(err)
-
-		<-done
 
 		commitParam := &awsSqs.DeleteMessageInput{
 			QueueUrl:      aws.String("example-1-url"),
@@ -252,7 +249,7 @@ func (suite *routeSuite) TestCommit() {
 
 	suite.Run("Should return error when commit error", func() {
 		suite.route = suite.setupRouter()
-		ctx, done := setupContext(1)
+		ctx := context.Background()
 		cParam := &awsSqs.GetQueueUrlInput{QueueName: aws.String("example-1")}
 		suite.sqsClient.On("GetQueueUrl", ctx, cParam).
 			Return(&awsSqs.GetQueueUrlOutput{QueueUrl: aws.String("example-1-url")}, nil).
@@ -264,6 +261,7 @@ func (suite *routeSuite) TestCommit() {
 			QueueUrl:                    aws.String("example-1-url"),
 			WaitTimeSeconds:             8,
 			MaxNumberOfMessages:         15,
+			VisibilityTimeout:           12,
 			MessageAttributeNames:       []string{"All"},
 			MessageSystemAttributeNames: []types.MessageSystemAttributeName{types.MessageSystemAttributeNameAll},
 		}
@@ -276,16 +274,8 @@ func (suite *routeSuite) TestCommit() {
 			}, nil).
 			Once()
 
-		suite.sqsClient.On("ChangeMessageVisibility", ctx, &awsSqs.ChangeMessageVisibilityInput{
-			QueueUrl:          aws.String("example-1-url"),
-			ReceiptHandle:     aws.String("receipt-handle"),
-			VisibilityTimeout: int32(12),
-		}).Return(nil, nil).Once()
-
 		message, err := suite.route.GetMessages(ctx, logger)
 		suite.NoError(err)
-
-		<-done
 
 		commitParam := &awsSqs.DeleteMessageInput{
 			QueueUrl:      aws.String("example-1-url"),
@@ -307,7 +297,7 @@ func (suite *routeSuite) TestHandlerMessage() {
 
 	suite.Run("should handler message", func() {
 		suite.route = suite.setupRouter()
-		ctx, done := setupContext(1)
+		ctx := context.Background()
 		cParam := &awsSqs.GetQueueUrlInput{QueueName: aws.String("example-1")}
 		suite.sqsClient.On("GetQueueUrl", ctx, cParam).
 			Return(&awsSqs.GetQueueUrlOutput{QueueUrl: aws.String("example-1-url")}, nil).
@@ -319,6 +309,7 @@ func (suite *routeSuite) TestHandlerMessage() {
 			QueueUrl:                    aws.String("example-1-url"),
 			WaitTimeSeconds:             8,
 			MaxNumberOfMessages:         15,
+			VisibilityTimeout:           12,
 			MessageAttributeNames:       []string{"All"},
 			MessageSystemAttributeNames: []types.MessageSystemAttributeName{types.MessageSystemAttributeNameAll},
 		}
@@ -331,25 +322,24 @@ func (suite *routeSuite) TestHandlerMessage() {
 			}, nil).
 			Once()
 
-		suite.sqsClient.On("ChangeMessageVisibility", ctx, &awsSqs.ChangeMessageVisibilityInput{
-			QueueUrl:          aws.String("example-1-url"),
-			ReceiptHandle:     aws.String("receipt-handle"),
-			VisibilityTimeout: int32(12),
-		}).Return(nil, nil).Once()
-
 		message, err := suite.route.GetMessages(ctx, logger)
 		suite.NoError(err)
-		suite.NoError(err)
-
-		<-done
 
 		err = suite.route.HandlerMessage(ctx, message[0])
 		suite.Nil(err)
+
+		// commit to dispatch the message, otherwise its changeMessageVisibility
+		// goroutine keeps ticking in the background for the rest of the test run.
+		suite.sqsClient.On("DeleteMessage", ctx, &awsSqs.DeleteMessageInput{
+			QueueUrl:      aws.String("example-1-url"),
+			ReceiptHandle: aws.String("receipt-handle"),
+		}).Return(nil, nil).Once()
+		suite.NoError(suite.route.Commit(ctx, message[0]))
 	})
 
 	suite.Run("should return error when handler message error", func() {
 		suite.route = suite.setupRouter()
-		ctx, done := setupContext(1)
+		ctx := context.Background()
 		cParam := &awsSqs.GetQueueUrlInput{QueueName: aws.String("example-1")}
 		suite.sqsClient.On("GetQueueUrl", ctx, cParam).
 			Return(&awsSqs.GetQueueUrlOutput{QueueUrl: aws.String("example-1-url")}, nil).
@@ -361,6 +351,7 @@ func (suite *routeSuite) TestHandlerMessage() {
 			QueueUrl:                    aws.String("example-1-url"),
 			WaitTimeSeconds:             8,
 			MaxNumberOfMessages:         15,
+			VisibilityTimeout:           12,
 			MessageAttributeNames:       []string{"All"},
 			MessageSystemAttributeNames: []types.MessageSystemAttributeName{types.MessageSystemAttributeNameAll},
 		}
@@ -373,16 +364,8 @@ func (suite *routeSuite) TestHandlerMessage() {
 			}, nil).
 			Once()
 
-		suite.sqsClient.On("ChangeMessageVisibility", ctx, &awsSqs.ChangeMessageVisibilityInput{
-			QueueUrl:          aws.String("example-1-url"),
-			ReceiptHandle:     aws.String("receipt-handle"),
-			VisibilityTimeout: int32(12),
-		}).Return(nil, nil).Once()
-
 		message, err := suite.route.GetMessages(ctx, logger)
 		suite.NoError(err)
-
-		<-done
 
 		suite.route = sqs.NewRoute(&sqs.Config{
 			SQSClient: suite.sqsClient,
@@ -469,10 +452,13 @@ func (suite *routeSuite) TestChangeVisibilityInitially() {
 	logger := new(fake.Logger)
 	logger.On("Log", mock.Anything).Return()
 
-	suite.Run("should change visibility timeout initially", func() {
+	suite.Run("should not change visibility timeout when the message is handled quickly", func() {
 		visibilityTimeout := 30
-		suite.route = sqs.NewRoute(&sqs.Config{
-			SQSClient: suite.sqsClient,
+		// isolated mock: we assert ChangeMessageVisibility is never called, so this must
+		// not share call history with other subtests in the suite.
+		sqsClient := fake.NewSQSClient(suite.T())
+		route := sqs.NewRoute(&sqs.Config{
+			SQSClient: sqsClient,
 			Handler: func(ctx context.Context, m loafergo.Message) error {
 				return nil
 			},
@@ -483,29 +469,30 @@ func (suite *routeSuite) TestChangeVisibilityInitially() {
 			sqs.RouteWithWaitTimeSeconds(10),
 		)
 
-		ctx, done := setupContext(1)
+		ctx := context.Background()
 
-		visibilityTimeout = int(suite.route.VisibilityTimeout(ctx))
+		visibilityTimeout = int(route.VisibilityTimeout(ctx))
 
 		receiptHandle := aws.String("receipt-handle")
 		queueUrl := aws.String("example-1-url")
 
 		cParam := &awsSqs.GetQueueUrlInput{QueueName: aws.String("example-1")}
-		suite.sqsClient.On("GetQueueUrl", ctx, cParam).
+		sqsClient.On("GetQueueUrl", ctx, cParam).
 			Return(&awsSqs.GetQueueUrlOutput{QueueUrl: queueUrl}, nil).
 			Once()
 
-		err := suite.route.Configure(ctx)
+		err := route.Configure(ctx)
 		suite.NoError(err)
 		param := &awsSqs.ReceiveMessageInput{
 			QueueUrl:                    queueUrl,
 			WaitTimeSeconds:             10,
 			MaxNumberOfMessages:         10,
+			VisibilityTimeout:           int32(visibilityTimeout),
 			MessageAttributeNames:       []string{"All"},
 			MessageSystemAttributeNames: []types.MessageSystemAttributeName{types.MessageSystemAttributeNameAll},
 		}
 
-		suite.sqsClient.On("ReceiveMessage", ctx, param).
+		sqsClient.On("ReceiveMessage", ctx, param).
 			Return(&awsSqs.ReceiveMessageOutput{
 				Messages: []types.Message{{
 					Body:          aws.String("hello world"),
@@ -514,29 +501,23 @@ func (suite *routeSuite) TestChangeVisibilityInitially() {
 			}, nil).
 			Once()
 
-		suite.sqsClient.On("ChangeMessageVisibility", ctx, &awsSqs.ChangeMessageVisibilityInput{
-			QueueUrl:          queueUrl,
-			ReceiptHandle:     receiptHandle,
-			VisibilityTimeout: int32(visibilityTimeout),
-		}).Return(nil, nil).Once()
-
-		messages, err := suite.route.GetMessages(ctx, logger)
+		messages, err := route.GetMessages(ctx, logger)
 		suite.NoError(err)
-
-		<-done
 
 		msg := messages[0]
 
-		err = suite.route.HandlerMessage(ctx, msg)
+		err = route.HandlerMessage(ctx, msg)
 		suite.Nil(err)
 
-		suite.sqsClient.On("DeleteMessage", ctx, &awsSqs.DeleteMessageInput{
+		sqsClient.On("DeleteMessage", ctx, &awsSqs.DeleteMessageInput{
 			QueueUrl:      queueUrl,
 			ReceiptHandle: receiptHandle,
 		}).Return(nil, nil).Once()
 
-		err = suite.route.Commit(ctx, msg)
+		err = route.Commit(ctx, msg)
 		suite.Nil(err)
+
+		sqsClient.AssertNotCalled(suite.T(), "ChangeMessageVisibility")
 	})
 
 }
@@ -578,6 +559,7 @@ func (suite *routeSuite) TestChangeVisibilityTimeout() {
 			QueueUrl:                    queueUrl,
 			WaitTimeSeconds:             10,
 			MaxNumberOfMessages:         10,
+			VisibilityTimeout:           int32(visibilityTimeout),
 			MessageAttributeNames:       []string{"All"},
 			MessageSystemAttributeNames: []types.MessageSystemAttributeName{types.MessageSystemAttributeNameAll},
 		}
@@ -628,7 +610,7 @@ func (suite *routeSuite) TestBackoff() {
 	logger := new(fake.Logger)
 	logger.On("Log", mock.Anything).Return()
 
-	suite.Run("should change visibility timeout initially and when backoff is called", func() {
+	suite.Run("should change visibility timeout when backoff is called", func() {
 		visibilityTimeout := 30
 		backoffTimeout := 10
 
@@ -645,7 +627,7 @@ func (suite *routeSuite) TestBackoff() {
 			sqs.RouteWithWaitTimeSeconds(10),
 		)
 
-		ctx, done := setupContext(2)
+		ctx, done := setupContext(1)
 
 		visibilityTimeout = int(suite.route.VisibilityTimeout(ctx))
 
@@ -663,6 +645,7 @@ func (suite *routeSuite) TestBackoff() {
 			QueueUrl:                    queueUrl,
 			WaitTimeSeconds:             10,
 			MaxNumberOfMessages:         10,
+			VisibilityTimeout:           int32(visibilityTimeout),
 			MessageAttributeNames:       []string{"All"},
 			MessageSystemAttributeNames: []types.MessageSystemAttributeName{types.MessageSystemAttributeNameAll},
 		}
@@ -676,12 +659,8 @@ func (suite *routeSuite) TestBackoff() {
 			}, nil).
 			Once()
 
-		suite.sqsClient.On("ChangeMessageVisibility", ctx, &awsSqs.ChangeMessageVisibilityInput{
-			QueueUrl:          queueUrl,
-			ReceiptHandle:     receiptHandle,
-			VisibilityTimeout: int32(visibilityTimeout),
-		}).Return(nil, nil).Once()
-
+		// Backoff overrides visibility immediately regardless of ticker timing, so this
+		// is the only ChangeMessageVisibility call expected here.
 		suite.sqsClient.On("ChangeMessageVisibility", ctx, &awsSqs.ChangeMessageVisibilityInput{
 			QueueUrl:          queueUrl,
 			ReceiptHandle:     receiptHandle,

--- a/aws/sqs/route_visibility_integration_test.go
+++ b/aws/sqs/route_visibility_integration_test.go
@@ -1,0 +1,178 @@
+//go:build integration
+
+package sqs_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/stretchr/testify/require"
+
+	loafergo "github.com/justcodes/loafer-go/v2"
+	loafersqs "github.com/justcodes/loafer-go/v2/aws/sqs"
+)
+
+// countingSQSClient wraps a real SQSClient and records every ChangeMessageVisibility
+// call by receipt handle, delegating everything else untouched.
+type countingSQSClient struct {
+	loafergo.SQSClient
+	mu    sync.Mutex
+	calls map[string]int
+}
+
+func newCountingSQSClient(c loafergo.SQSClient) *countingSQSClient {
+	return &countingSQSClient{SQSClient: c, calls: make(map[string]int)}
+}
+
+func (c *countingSQSClient) ChangeMessageVisibility(
+	ctx context.Context,
+	params *sqs.ChangeMessageVisibilityInput,
+	optFns ...func(*sqs.Options),
+) (*sqs.ChangeMessageVisibilityOutput, error) {
+	c.mu.Lock()
+	c.calls[*params.ReceiptHandle]++
+	c.mu.Unlock()
+	return c.SQSClient.ChangeMessageVisibility(ctx, params, optFns...)
+}
+
+func (c *countingSQSClient) count(receiptHandle string) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls[receiptHandle]
+}
+
+// TestIntegrationVisibilityCallsAgainstLocalStack drives real messages through a route backed by
+// a LocalStack SQS queue, using handlers with a random execution time, and reports how
+// many real ChangeMessageVisibility calls each message triggered. It exists to validate
+// end-to-end, against the real SQS API surface, that visibility is only extended when a
+// message is still being processed - not for every message received.
+//
+// Requires LocalStack running locally:
+//
+//	docker compose -f docker-compose.integration.yml up -d
+//	go test -tags=integration -race -run TestIntegrationVisibilityCallsAgainstLocalStack ./aws/sqs/... -v
+func TestIntegrationVisibilityCallsAgainstLocalStack(t *testing.T) {
+	const (
+		messageCount      = 20
+		maxMessages       = int32(10) // SQS caps ReceiveMessage at 10 per call
+		visibilityTimeout = int32(11) // sleepTime = visibilityTimeout - 10 = 1s
+		sleepTime         = 1 * time.Second
+		maxHandlerSleep   = 2200 * time.Millisecond
+		margin            = 400 * time.Millisecond // avoids flaky asserts right at tick boundaries
+	)
+
+	ctx := context.Background()
+	endpoint := envOr("AWS_ENDPOINT", "http://localhost:4566")
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("dummy", "dummy", "")),
+	)
+	require.NoError(t, err)
+	awsCfg.BaseEndpoint = aws.String(endpoint)
+
+	rawClient := sqs.NewFromConfig(awsCfg)
+
+	queueName := fmt.Sprintf("visibility-load-test-%d", time.Now().UnixNano())
+	createOut, err := rawClient.CreateQueue(ctx, &sqs.CreateQueueInput{QueueName: &queueName})
+	require.NoError(t, err)
+	queueURL := createOut.QueueUrl
+	t.Cleanup(func() {
+		_, _ = rawClient.DeleteQueue(context.Background(), &sqs.DeleteQueueInput{QueueUrl: queueURL})
+	})
+
+	durationByBody := make(map[string]time.Duration, messageCount)
+	for i := 0; i < messageCount; i++ {
+		body := fmt.Sprintf("message-%d", i)
+		durationByBody[body] = rand.N(maxHandlerSleep)
+
+		_, err := rawClient.SendMessage(ctx, &sqs.SendMessageInput{
+			QueueUrl:    queueURL,
+			MessageBody: aws.String(body),
+		})
+		require.NoError(t, err)
+	}
+
+	countingClient := newCountingSQSClient(rawClient)
+
+	handler := func(ctx context.Context, m loafergo.Message) error {
+		time.Sleep(durationByBody[string(m.Body())])
+		return nil
+	}
+
+	route := loafersqs.NewRoute(&loafersqs.Config{
+		SQSClient: countingClient,
+		Handler:   handler,
+		QueueName: queueName,
+	},
+		loafersqs.RouteWithVisibilityTimeout(visibilityTimeout),
+		loafersqs.RouteWithMaxMessages(maxMessages),
+		loafersqs.RouteWithWaitTimeSeconds(2),
+	)
+	require.NoError(t, route.Configure(ctx))
+
+	allMessages := make([]loafergo.Message, 0, messageCount)
+	deadline := time.Now().Add(20 * time.Second)
+	for len(allMessages) < messageCount && time.Now().Before(deadline) {
+		batch, err := route.GetMessages(ctx, loafergo.NoOpLogger{})
+		require.NoError(t, err)
+		allMessages = append(allMessages, batch...)
+	}
+	require.Len(t, allMessages, messageCount)
+
+	var wg sync.WaitGroup
+	for _, msg := range allMessages {
+		msg := msg
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = route.HandlerMessage(ctx, msg)
+			_ = route.Commit(ctx, msg)
+		}()
+	}
+	wg.Wait()
+
+	totalCalls := 0
+	fmt.Println("\nbody           duration        visibility_calls")
+	for _, msg := range allMessages {
+		body := string(msg.Body())
+		d := durationByBody[body]
+		calls := countingClient.count(msg.Identifier())
+		totalCalls += calls
+		fmt.Printf("%-14s %-15s %d\n", body, d, calls)
+
+		switch {
+		case d < sleepTime-margin:
+			if calls != 0 {
+				t.Errorf("message %s: duration %s finished well before the first tick, expected 0 visibility calls, got %d", body, d, calls)
+			}
+		case d > sleepTime+margin && d < 2*sleepTime-margin:
+			if calls < 1 {
+				t.Errorf("message %s: duration %s crossed one tick, expected at least 1 visibility call, got %d", body, d, calls)
+			}
+		case d > 2*sleepTime+margin:
+			if calls < 2 {
+				t.Errorf("message %s: duration %s crossed two ticks, expected at least 2 visibility calls, got %d", body, d, calls)
+			}
+		}
+	}
+
+	fmt.Printf("\nmessages=%d totalVisibilityCalls=%d avgCallsPerMessage=%.2f\n",
+		messageCount, totalCalls, float64(totalCalls)/float64(messageCount))
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -1,0 +1,8 @@
+services:
+  localstack:
+    container_name: "loafer-integration-localstack"
+    image: localstack/localstack
+    ports:
+      - "127.0.0.1:4566:4566"
+    environment:
+      - AWS_DEFAULT_REGION=us-east-1


### PR DESCRIPTION
### Summary
- `ChangeMessageVisibility` was previously called unconditionally and immediately for every message received, regardless of how fast the handler finished — costing one billable API call per message even when it was never at risk of expiring.
- `route.GetMessages` now passes `VisibilityTimeout` directly on the `ReceiveMessage` call (`aws/sqs/route.go`), so the initial timeout is guaranteed for free instead of via a follow-up API call.
- `changeMessageVisibility` no longer fires before entering its ticker loop. It only calls `ChangeMessageVisibility` when the ticker actually fires (i.e., the message is still being processed close to timeout expiry) or when `Backoff()` is used. The total extension budget (`extensionLimit + 1` calls, with doubling) is unchanged — only *when* those calls happen changed.
- Net effect: messages that finish well within the visibility timeout now trigger **zero** `ChangeMessageVisibility` calls instead of at least one.

### Tests
- Updated `aws/sqs/route_test.go` to match the new call expectations (most fast-path subtests now assert no `ChangeMessageVisibility` call at all; `TestBackoff` no longer expects the old "initial" call).
- Fixed two pre-existing goroutine leaks surfaced while updating the tests: `TestGetMessages`/`TestHandlerMessage` subtests left messages uncommitted, so their background visibility-tracking goroutine kept ticking against a shared mock for the rest of the test run. Both subtests now commit the message to deterministically terminate the goroutine.
- Added `aws/sqs/route_visibility_integration_test.go` (build tag `integration`): drives real messages through a route backed by an actual LocalStack SQS queue, using handlers with randomized execution time, and asserts the number of real `ChangeMessageVisibility` calls matches expectations (0 calls for fast messages, ≥1 for messages that cross one tick, ≥2 for two ticks).
- Added `docker-compose.integration.yml` and a `make test-integration` target to spin up LocalStack, run the integration test, and tear it down.

### Verification
- `go test -race -cover ./...` — all green.
- `go vet`, `goimports`, `fieldalignment` — clean.
- Integration test run repeatedly against a live LocalStack container, stable across runs with randomized durations.